### PR TITLE
Add Vercel deployment config and demo user support

### DIFF
--- a/VERCEL_DEPLOYMENT.md
+++ b/VERCEL_DEPLOYMENT.md
@@ -1,0 +1,97 @@
+# Deploying EcoCreds Frontend to Vercel
+
+This guide explains how to deploy the EcoCreds frontend to Vercel as a static single-page application (SPA).
+
+## Quick Deployment
+
+### Option 1: Using Vercel CLI
+
+1. Install Vercel CLI globally:
+
+   ```bash
+   npm install -g vercel
+   ```
+
+2. Login to Vercel:
+
+   ```bash
+   vercel login
+   ```
+
+3. Deploy the project:
+   ```bash
+   vercel --prod
+   ```
+
+### Option 2: Using Vercel Dashboard
+
+1. Go to [vercel.com](https://vercel.com) and sign in
+2. Click "New Project"
+3. Import your GitHub repository
+4. Vercel will automatically detect the configuration from `vercel.json`
+5. Click "Deploy"
+
+## Configuration
+
+The project includes a `vercel.json` file that:
+
+- Builds only the frontend using `npm run build:client`
+- Serves files from the `dist/spa` directory
+- Handles client-side routing by redirecting all routes to `index.html`
+
+## Demo Features
+
+The deployed app includes:
+
+- **Demo Authentication**: Works without a backend using localStorage
+- **Demo Users**:
+  - Email: `alex@example.com`, Password: `password`
+  - Email: `demo@example.com`, Password: `demo`
+- **Offline Support**: All features work without API connectivity
+- **Local Storage**: User data and activities are saved locally
+
+## Build Commands
+
+- `npm run build:client` - Build frontend for production
+- `npm run dev` - Development server (includes backend)
+
+## Troubleshooting
+
+### Blank Page Issues
+
+- Ensure you're using the latest `vercel.json` configuration
+- Check browser console for JavaScript errors
+- Verify the build completed successfully
+
+### Routing Issues
+
+- The SPA routing is handled by the `routes` configuration in `vercel.json`
+- All routes redirect to `index.html` to enable client-side routing
+
+### API Features
+
+- The frontend-only deployment doesn't include backend APIs
+- User authentication and data storage work through localStorage
+- For full backend features, deploy the backend separately or use Vercel Functions
+
+## Environment Variables
+
+No environment variables are required for the frontend-only deployment.
+
+## Performance
+
+The build includes:
+
+- Code splitting and optimization via Vite
+- CSS minification
+- Asset optimization
+- Gzip compression enabled by Vercel
+
+## Custom Domain
+
+To use a custom domain:
+
+1. Go to your Vercel project dashboard
+2. Click "Settings" > "Domains"
+3. Add your custom domain
+4. Follow Vercel's DNS configuration instructions

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -51,6 +51,31 @@ export default function Index() {
               footprint, earn EcoCredits, and make a positive impact on the
               planet.
             </p>
+
+            {/* Demo Credentials */}
+            <Card className="mb-8 bg-eco-50 border-eco-200">
+              <CardHeader>
+                <CardTitle className="text-eco-700">Try the Demo</CardTitle>
+              </CardHeader>
+              <CardContent className="text-left">
+                <p className="text-sm text-muted-foreground mb-4">
+                  Use these demo credentials to explore the app:
+                </p>
+                <div className="space-y-2 text-sm">
+                  <div className="bg-white p-3 rounded border">
+                    <strong>Email:</strong> alex@example.com
+                    <br />
+                    <strong>Password:</strong> password
+                  </div>
+                  <div className="bg-white p-3 rounded border">
+                    <strong>Email:</strong> demo@example.com
+                    <br />
+                    <strong>Password:</strong> demo
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+
             <div className="flex gap-4 justify-center">
               <Button asChild size="lg">
                 <Link to="/signup">Get Started</Link>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Hello world project</title>
+    <title>EcoCreds - Sustainable Shopping Platform</title>
   </head>
 
   <body>

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,15 @@
 {
   "version": 2,
-  "buildCommand": "npm run build:client",
-  "outputDirectory": "dist/spa",
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/static-build",
+      "config": {
+        "buildCommand": "npm run build:client",
+        "distDir": "dist/spa"
+      }
+    }
+  ],
   "routes": [
     {
       "src": "/(.*)",


### PR DESCRIPTION
This pull request adds support for deploying the EcoCreds frontend to Vercel as a static single-page application.

**Changes made:**

- Added `VERCEL_DEPLOYMENT.md` with comprehensive deployment guide
- Updated `vercel.json` configuration for proper SPA routing and build setup
- Modified `ActivityContext.tsx` to prioritize localStorage and include demo activities for new users
- Enhanced `AuthContext.tsx` with fallback authentication for two demo users (alex@example.com and demo@example.com)
- Added demo credentials display on the homepage (`Index.tsx`)
- Updated page title in `index.html` from "Hello world project" to "EcoCreds - Sustainable Shopping Platform"

**Key features:**
- Frontend-only deployment with offline functionality
- Demo authentication using localStorage
- User-specific activity caching
- Graceful API fallback when backend is unavailable
- Client-side routing support for SPA deployment

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/78e898bf5f844dc79abcaa2d0786a99c/curry-sanctuary)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>78e898bf5f844dc79abcaa2d0786a99c</projectId>-->
<!--<branchName>curry-sanctuary</branchName>-->